### PR TITLE
feat :  aipet ページの分離、および分離

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -11,8 +11,8 @@
 ### 주요 기술 스택
 - **상태 관리**: Riverpod (flutter_riverpod, riverpod_annotation)
 - **라우팅**: GoRouter (go_router)
-- **목업/테스트**: Mockito 
-- **API 연계 전까지**: mock_data 폴더의 Mock 데이터 사용
+- **목업/테스트**: Mockito
+- **API 연계 전까지**: mock_data 폴더의 Mock 데이터 사용을 위하여, 기본 코드는 api를 추후 연계하는 것을 기본으로 mockito 사용하도록 코드를 계획합니다.
 
 ## 아키텍처 원칙
 
@@ -20,7 +20,8 @@
 - **Presentation Layer**: UI 위젯, 화면, 사용자 인터랙션 처리
 - **Domain Layer**: 엔티티, 비즈니스 로직, 리포지토리 인터페이스
 - **Data Layer**: API 호출, 로컬 저장소, Mock 데이터 관리
-- **Infrastructure Layer**: HTTP 클라이언트, 로컬 DB(SQLite), 외부 서비스 연동
+- **Infrastructure Layer**: 현재는 mock_data 사용, 추후 API 연동시 변경 예정
+- **UI & Logic 분리**: ui, Logic을 분리하여 작성하여 DRY원칙을 적용합니다.
 
 ### 2. Flutter 앱 폴더 구조
 ```
@@ -31,12 +32,13 @@ lib/
 │   ├── providers/          # 앱 상태, 초기화 프로바이더
 │   └── router/             # GoRouter 설정 및 라우트 정의
 ├── features/               # 기능별 Feature 모듈
-│   ├── auth/              # 로그인, 회원가입
-│   ├── home/              # 메인 대시보드
-│   ├── pet_profile/       # 펫 프로필 관리
-│   ├── walk/              # 산책 기록
-│   ├── facility/          # 시설 검색
-│   └── ...                # 기타 기능들
+│   ├── auth/               # 로그인, 회원가입
+│   ├── home/               # 메인 대시보드
+│   ├── pet_profile/        # 펫 프로필 관리
+│   ├── walk/               # 산책 기록
+│   ├── facility/           # 시설 검색
+│   ├── ai/                 # AI 챗봇
+│   └── ...                 # 기타 기능들
 └── shared/                # 앱 전체에서 공유하는 리소스
     ├── design/            # 테마, 색상, 폰트 등 디자인 시스템
     ├── services/          # API 서비스, 로컬 저장소 등
@@ -69,7 +71,7 @@ lib/
 import 'dart:async';
 import 'dart:convert';
 
-// 2. Flutter 패키지 
+// 2. Flutter 패키지
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -96,7 +98,7 @@ import 'controllers/auth_controller.dart';
   import '../../../features/home/home.dart';
   import '../../../shared/shared.dart';
 
-  // ❌ 잘못된 예시  
+  // ❌ 잘못된 예시
   import '../../../features/auth/presentation/screens/login_screen.dart';
   import '../../../features/home/domain/entities/home_entity.dart';
   import '../../../shared/widgets/custom_button.dart';
@@ -107,7 +109,7 @@ import 'controllers/auth_controller.dart';
   // ✅ 올바른 예시 (같은 feature 내부)
   import '../domain/domain.dart';           // 레이어 배럴
   import 'widgets/login_form.dart';         // 직접 import (같은 레이어)
-  
+
   // ❌ 잘못된 예시
   import '../../../features/auth/domain/entities/user.dart';  // 너무 긴 경로
   ```
@@ -125,7 +127,7 @@ import 'controllers/auth_controller.dart';
 
 1. **Layer별 배럴 파일** (각 레이어 내부)
    - `data/data.dart`: data 레이어의 모든 파일 export
-   - `domain/domain.dart`: domain 레이어의 모든 파일 export  
+   - `domain/domain.dart`: domain 레이어의 모든 파일 export
    - `presentation/presentation.dart`: presentation 레이어의 모든 파일 export
 
 2. **Feature 최종 배럴** (feature 루트)
@@ -140,14 +142,14 @@ export 'repositories/auth_repository_impl.dart';
 export 'datasources/auth_remote_datasource.dart';
 export 'models/user_model.dart';
 
-// lib/features/auth/domain/domain.dart  
+// lib/features/auth/domain/domain.dart
 export 'entities/user.dart';
 export 'repositories/auth_repository.dart';
 export 'usecases/login_usecase.dart';
 
 // lib/features/auth/presentation/presentation.dart
 export 'screens/login_screen.dart';
-export 'widgets/login_form.dart'; 
+export 'widgets/login_form.dart';
 export 'controllers/auth_controller.dart';
 
 // lib/features/auth/auth.dart (최종 배럴)
@@ -232,7 +234,7 @@ lib/features/auth/
   // 페이지 이동
   context.go(AppRouter.homeRoute);
   context.push(AppRouter.petDetailRoute);
-  
+
   // 매개변수가 있는 라우트
   context.goNamed('petDetail', pathParameters: {'petId': petId});
   ```
@@ -294,7 +296,7 @@ class HomeController extends BaseController {
   ```dart
   // ✅ 올바른 예시
   Text('ログイン')                    // 로그인
-  Text('ペットプロフィール')           // 펫 프로필  
+  Text('ペットプロフィール')           // 펫 프로필
   Text('設定')                       // 설정
   AppLocalizations.of(context)?.loginButtonText ?? 'ログイン'
 
@@ -307,7 +309,7 @@ class HomeController extends BaseController {
   ```dart
   // 권장 방식
   Text(AppLocalizations.of(context)?.loginTitle ?? 'ログイン')
-  
+
   // 임시 방식 (개발 단계)
   Text('ログイン')
   ```
@@ -321,7 +323,7 @@ class HomeController extends BaseController {
 ```dart
 // 공통 UI 텍스트
 'ログイン'          // 로그인
-'ログアウト'        // 로그아웃  
+'ログアウト'        // 로그아웃
 '保存'            // 저장
 'キャンセル'        // 취소
 '確認'            // 확인
@@ -361,7 +363,7 @@ try {
 
 ### 2. 사용자 피드백 (일본어)
 - **성공**: `showSuccess('保存しました')` - 저장했습니다
-- **경고**: `showWarning('接続を確認してください')` - 연결을 확인해주세요  
+- **경고**: `showWarning('接続を確認してください')` - 연결을 확인해주세요
 - **정보**: `showInfo('データを更新中です')` - 데이터를 업데이트 중입니다
 - **SnackBar**: 짧은 피드백 메시지
 - **Dialog**: 중요한 확인이나 에러 메시지
@@ -417,11 +419,11 @@ import 'pet_repository_test.mocks.dart';
 
 void main() {
   late MockPetRepository mockRepository;
-  
+
   setUp(() {
     mockRepository = MockPetRepository();
   });
-  
+
   testWidgets('pet list display test', (tester) async {
     when(mockRepository.fetchPets())
         .thenAnswer((_) async => MockPetData.pets);
@@ -505,7 +507,7 @@ flutter test
 git commit -m "feat(auth): ログイン画面のUI実装"
 git commit -m "feat(pet): ペットプロフィール登録機能を追加"
 
-# 버그 수정  
+# 버그 수정
 git commit -m "fix(walk): 散歩時間計算のエラーを修正"
 git commit -m "fix(ui): ローディング状態でボタンを無効化する処理を追加"
 
@@ -555,5 +557,5 @@ git commit -m "test(auth): ログイン処理の統合テストを実装"
 
 ---
 
-**이 가이드라인을 따라 일관성 있고 확장 가능한 Flutter 앱을 개발하세요.**  
+**이 가이드라인을 따라 일관성 있고 확장 가능한 Flutter 앱을 개발하세요.**
 **Backend API와의 연계는 별도 프로젝트에서 처리되므로, Frontend는 UI/UX와 상태 관리에 집중합니다.**

--- a/lib/app/providers/app_initialization_provider.g.dart
+++ b/lib/app/providers/app_initialization_provider.g.dart
@@ -6,9 +6,11 @@ part of 'app_initialization_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$appInitializationHash() => r'370ea87285d5ea8ca324fce8da381e33fd698b19';
+String _$appInitializationHash() => r'8013709941c94dfbb01e1966e7f3c02a6a8ad7fa';
 
-/// 앱 초기화 상태 관리
+/// 앱 초기화 상태를 관리하는 Provider
+///
+/// 앱 시작 시 필요한 모든 초기화 작업을 관리하고 상태를 추적합니다.
 ///
 /// Copied from [AppInitialization].
 @ProviderFor(AppInitialization)

--- a/lib/app/providers/app_state_provider.g.dart
+++ b/lib/app/providers/app_state_provider.g.dart
@@ -8,7 +8,9 @@ part of 'app_state_provider.dart';
 
 String _$appStateHash() => r'61bd04d66a1e6f6493361cae94ccb7114cd7dcde';
 
-/// 앱 전체 상태 관리
+/// 앱 전체 상태를 관리하는 Provider
+///
+/// 앱의 전역 상태를 관리하며, 로딩, 에러, 시간, 온라인 상태 등을 추적합니다.
 ///
 /// Copied from [AppState].
 @ProviderFor(AppState)

--- a/lib/features/ai/ai.dart
+++ b/lib/features/ai/ai.dart
@@ -1,2 +1,3 @@
-export 'domain/entities/entities.dart';
-export 'presentation/screens/ai_chat_screen.dart';
+export 'data/data.dart';
+export 'domain/domain.dart';
+export 'presentation/presentation.dart';

--- a/lib/features/ai/data/data.dart
+++ b/lib/features/ai/data/data.dart
@@ -1,1 +1,2 @@
+export 'providers/ai_providers.dart';
 export 'repositories/ai_repository_impl.dart';

--- a/lib/features/ai/data/providers/ai_providers.dart
+++ b/lib/features/ai/data/providers/ai_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../domain/domain.dart';
+import '../repositories/ai_repository_impl.dart';
+
+part 'ai_providers.g.dart';
+
+/// AI Repository Provider
+/// 
+/// 실제 API 연계 시점에는 AiRepositoryImpl을 실제 API 구현체로 교체하면 됩니다.
+@riverpod
+AiRepository aiRepository(Ref ref) {
+  return AiRepositoryImpl();
+}

--- a/lib/features/ai/data/providers/ai_providers.g.dart
+++ b/lib/features/ai/data/providers/ai_providers.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ai_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$aiRepositoryHash() => r'8bf3fb9051e43822150e4d5104c169dc94843f0e';
+
+/// AI Repository Provider
+///
+/// 실제 API 연계 시점에는 AiRepositoryImpl을 실제 API 구현체로 교체하면 됩니다.
+///
+/// Copied from [aiRepository].
+@ProviderFor(aiRepository)
+final aiRepositoryProvider = AutoDisposeProvider<AiRepository>.internal(
+  aiRepository,
+  name: r'aiRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$aiRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AiRepositoryRef = AutoDisposeProviderRef<AiRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/ai/data/repositories/ai_repository_impl.dart
+++ b/lib/features/ai/data/repositories/ai_repository_impl.dart
@@ -1,45 +1,62 @@
 import 'package:flutter/material.dart';
 
-import '../../domain/entities/ai_message_entity.dart';
-import '../../domain/repositories/ai_repository.dart';
+import '../../../../shared/shared.dart';
+import '../../domain/domain.dart';
 
 class AiRepositoryImpl implements AiRepository {
   @override
   Future<List<AiMessageEntity>> getChatHistory() async {
-    // TODO: Implement actual chat history retrieval
-    // For now, return mock data
-    return [
-      AiMessageEntity(
-        id: '1',
-        content: 'AI와 대화를 시작하세요!',
-        type: MessageType.assistant,
-        timestamp: DateTime.now().subtract(const Duration(minutes: 5)),
-      ),
-    ];
+    // TODO: Replace with actual API call
+    // final response = await _httpClient.get('/api/ai/chat/history');
+    // return response.data.map((json) => AiMessageEntity.fromJson(json)).toList();
+    
+    await AiMockDataService.simulateApiDelay();
+    final mockData = AiMockDataService.getChatHistoryMockData();
+    
+    return mockData.map((json) => AiMessageEntity(
+      id: json['id'] as String,
+      content: json['content'] as String,
+      type: _parseMessageType(json['type'] as String),
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    )).toList();
   }
 
   @override
   Future<AiMessageEntity> sendMessage(String message) async {
-    // TODO: Implement actual AI API call
-    // For now, return mock response
-    await Future.delayed(const Duration(seconds: 1)); // Simulate API delay
-
+    // TODO: Replace with actual API call
+    // final response = await _httpClient.post('/api/ai/chat/send', {
+    //   'message': message,
+    // });
+    // return AiMessageEntity.fromJson(response.data);
+    
+    await AiMockDataService.simulateApiDelay(seconds: 2);
+    final mockData = AiMockDataService.generateAiResponseMockData(message);
+    
     return AiMessageEntity(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      content: 'AI 응답: $message에 대한 답변입니다.',
-      type: MessageType.assistant,
-      timestamp: DateTime.now(),
+      id: mockData['id'] as String,
+      content: mockData['content'] as String,
+      type: _parseMessageType(mockData['type'] as String),
+      timestamp: DateTime.parse(mockData['timestamp'] as String),
     );
   }
 
   @override
   Future<void> clearChatHistory() async {
-    // TODO: Implement chat history clearing
+    // TODO: Replace with actual API call
+    // await _httpClient.delete('/api/ai/chat/history');
+    
+    await AiMockDataService.simulateApiDelay();
+    // Mock implementation: no actual storage to clear
   }
 
   @override
   Future<List<AiChatSessionEntity>> getChatSessions() async {
-    // TODO: Implement actual chat sessions retrieval
+    // TODO: Replace with actual API call
+    // final response = await _httpClient.get('/api/ai/chat/sessions');
+    // return response.data.map((json) => AiChatSessionEntity.fromJson(json)).toList();
+    
+    await AiMockDataService.simulateApiDelay();
+    // Mock implementation: return empty list
     return [];
   }
 
@@ -48,40 +65,66 @@ class AiRepositoryImpl implements AiRepository {
     String title, {
     String? petId,
   }) async {
-    // TODO: Implement actual chat session creation
+    // TODO: Replace with actual API call
+    // final response = await _httpClient.post('/api/ai/chat/sessions', {
+    //   'title': title,
+    //   'petId': petId,
+    // });
+    // return AiChatSessionEntity.fromJson(response.data);
+    
+    await AiMockDataService.simulateApiDelay();
+    final mockData = AiMockDataService.createChatSessionMockData(title, petId: petId);
+    
     return AiChatSessionEntity(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      title: title,
+      id: mockData['id'] as String,
+      title: mockData['title'] as String,
       messages: [],
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-      petId: petId,
+      createdAt: DateTime.parse(mockData['createdAt'] as String),
+      updatedAt: DateTime.parse(mockData['updatedAt'] as String),
+      petId: mockData['petId'] as String?,
+      petName: mockData['petName'] as String?,
     );
   }
 
   @override
   Future<void> deleteChatSession(String sessionId) async {
-    // TODO: Implement chat session deletion
+    // TODO: Replace with actual API call
+    // await _httpClient.delete('/api/ai/chat/sessions/$sessionId');
+    
+    await AiMockDataService.simulateApiDelay();
+    // Mock implementation: no actual storage to delete from
   }
 
   @override
   Future<List<AiSuggestedQuestionEntity>> getSuggestedQuestions() async {
-    // TODO: Implement suggested questions retrieval
-    return [
-      const AiSuggestedQuestionEntity(
-        id: '1',
-        question: '우리 강아지 건강 상태는 어떤가요?',
-        category: '건강',
-        icon: Icons.health_and_safety,
-        description: '반려동물의 전반적인 건강 상태를 확인합니다',
+    // TODO: Replace with actual API call
+    // final response = await _httpClient.get('/api/ai/suggested-questions');
+    // return response.data.map((json) => AiSuggestedQuestionEntity.fromJson(json)).toList();
+    
+    await AiMockDataService.simulateApiDelay();
+    
+    return AiMockDataService.suggestedQuestions.map((data) => 
+      AiSuggestedQuestionEntity(
+        id: data['id'] as String,
+        question: data['question'] as String,
+        category: data['category'] as String,
+        icon: data['icon'] as IconData,
+        description: data['description'] as String?,
       ),
-      const AiSuggestedQuestionEntity(
-        id: '2',
-        question: '산책 일정을 추천해 주세요',
-        category: '활동',
-        icon: Icons.pets,
-        description: '최적의 산책 시간과 장소를 추천합니다',
-      ),
-    ];
+    ).toList();
+  }
+
+  /// MessageType 문자열을 enum으로 파싱
+  MessageType _parseMessageType(String typeString) {
+    switch (typeString.toLowerCase()) {
+      case 'user':
+        return MessageType.user;
+      case 'assistant':
+        return MessageType.assistant;
+      case 'system':
+        return MessageType.system;
+      default:
+        return MessageType.assistant;
+    }
   }
 }

--- a/lib/features/ai/domain/domain.dart
+++ b/lib/features/ai/domain/domain.dart
@@ -1,0 +1,2 @@
+export 'entities/entities.dart';
+export 'repositories/repositories.dart';

--- a/lib/features/ai/presentation/controllers/ai_chat_controller.dart
+++ b/lib/features/ai/presentation/controllers/ai_chat_controller.dart
@@ -1,75 +1,79 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
-import '../../domain/entities/ai_message_entity.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-/// AI 채팅 컨트롤러
-///
-/// AI 채팅의 비즈니스 로직을 담당합니다.
-class AiChatController {
-  final List<AiMessageEntity> _messages = [];
-  final List<AiSuggestedQuestionEntity> _suggestedQuestions = [];
+import '../../../../app/controllers/base_controller.dart';
+import '../../data/data.dart';
+import '../../domain/domain.dart';
 
-  AiChatController() {
-    _initializeMessages();
-    _initializeSuggestedQuestions();
-  }
+part 'ai_chat_controller.g.dart';
 
-  /// 메시지 목록 가져오기
-  List<AiMessageEntity> get messages => List.unmodifiable(_messages);
+/// AI 채팅 상태 데이터
+class AiChatState {
+  final List<AiMessageEntity> messages;
+  final List<AiSuggestedQuestionEntity> suggestedQuestions;
+  final bool isTyping;
+  final String? error;
 
-  /// 추천 질문 목록 가져오기
-  List<AiSuggestedQuestionEntity> get suggestedQuestions =>
-      List.unmodifiable(_suggestedQuestions);
+  const AiChatState({
+    this.messages = const [],
+    this.suggestedQuestions = const [],
+    this.isTyping = false,
+    this.error,
+  });
 
-  /// 초기 메시지 설정
-  void _initializeMessages() {
-    _messages.add(
-      AiMessageEntity(
-        id: '1',
-        content: 'こんにちは！ aipetアシスタントです。 何かお手伝いできますか? 🐾',
-        type: MessageType.assistant,
-        timestamp: DateTime.now().subtract(const Duration(minutes: 5)),
-      ),
+  AiChatState copyWith({
+    List<AiMessageEntity>? messages,
+    List<AiSuggestedQuestionEntity>? suggestedQuestions,
+    bool? isTyping,
+    String? error,
+  }) {
+    return AiChatState(
+      messages: messages ?? this.messages,
+      suggestedQuestions: suggestedQuestions ?? this.suggestedQuestions,
+      isTyping: isTyping ?? this.isTyping,
+      error: error ?? this.error,
     );
   }
+}
 
-  /// 추천 질문 초기화
-  void _initializeSuggestedQuestions() {
-    _suggestedQuestions.addAll([
-      const AiSuggestedQuestionEntity(
-        id: '1',
-        question: 'お腹の調子が悪い',
-        category: '食事',
-        icon: Icons.restaurant,
-        description: '食事量が少ない理由と解決策',
-      ),
-      const AiSuggestedQuestionEntity(
-        id: '2',
-        question: '散歩の時間はどれくらいかかりますか?',
-        category: '運動',
-        icon: Icons.directions_walk,
-        description: '適切な運動量のガイド',
-      ),
-      const AiSuggestedQuestionEntity(
-        id: '3',
-        question: '予防接種のスケジュールが気になります',
-        category: '健康',
-        icon: Icons.medical_services,
-        description: '予防接種の予定の案内',
-      ),
-      const AiSuggestedQuestionEntity(
-        id: '4',
-        question: '毛づくりのマニュアル',
-        category: 'メンテナンス',
-        icon: Icons.content_cut,
-        description: '季節別毛づくりのマニュアル',
-      ),
-    ]);
+/// AI 채팅 상태 프로바이더
+@riverpod
+class AiChatNotifier extends _$AiChatNotifier {
+  @override
+  AiChatState build() {
+    // 초기 상태는 빈 상태로 시작하고, 실제 데이터는 repository를 통해 로드
+    return const AiChatState();
+  }
+
+  /// 초기 데이터 로드
+  Future<void> initializeChat() async {
+    final repository = ref.read(aiRepositoryProvider);
+    
+    try {
+      final messages = await repository.getChatHistory();
+      final suggestedQuestions = await repository.getSuggestedQuestions();
+      
+      state = state.copyWith(
+        messages: messages,
+        suggestedQuestions: suggestedQuestions,
+        error: null,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        error: error.toString(),
+      );
+    }
   }
 
   /// 메시지 전송
   Future<void> sendMessage(String content) async {
     if (content.trim().isEmpty) return;
+    
+    final repository = ref.read(aiRepositoryProvider);
+
+    // 타이핑 상태 시작
+    state = state.copyWith(isTyping: true);
 
     // 사용자 메시지 추가
     final userMessage = AiMessageEntity(
@@ -79,105 +83,108 @@ class AiChatController {
       timestamp: DateTime.now(),
     );
 
-    _messages.add(userMessage);
-    _notifyMessagesChanged();
+    final updatedMessages = [...state.messages, userMessage];
+    state = state.copyWith(messages: updatedMessages);
 
-    // AI 응답 생성
-    final aiResponse = await _generateAiResponse(content.trim());
-    _messages.add(aiResponse);
-    _notifyMessagesChanged();
-  }
-
-  /// AI 응답 생성
-  Future<AiMessageEntity> _generateAiResponse(String userMessage) async {
-    // 실제로는 AI API 호출
-    await Future.delayed(const Duration(seconds: 2));
-
-    final String aiResponse = _getResponseByKeyword(userMessage);
-
-    return AiMessageEntity(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      content: aiResponse,
-      type: MessageType.assistant,
-      timestamp: DateTime.now(),
-    );
-  }
-
-  /// 키워드별 응답 생성
-  String _getResponseByKeyword(String userMessage) {
-    if (userMessage.contains('食事') ||
-        userMessage.contains('食事量') ||
-        userMessage.contains('食事量が少ない')) {
-      return '''🍽️ お腹の調子が悪い理由はたくさんあります:
-
-1. **健康上の問題**: 歯の問題, 消化器の問題
-2. **ストレス**: 環境の変化, 新しい食事
-3. **活動量不足**: 運動が不足すると食欲が落ちます
-
-**解決策:**
-• 定められた時間に定期的に食事定められた時間に定期的に食事
-• 食器を清潔に保つ
-• 十分な運動でエネルギーを消費
-• 継続的に症状があれば獣医師に相談を推奨継続的に症状があれば獣医師に相談を推奨''';
-    } else if (userMessage.contains('散歩') || userMessage.contains('運動')) {
-      return '''🚶‍♂️ ペットの散歩ガイド:ペットの散歩ガイド
-
-**小型犬 (5kg 未満)**
-• 1日30-60分 (2-3回に分けて)2-3回に分けて
-
-**中型犬 (5-25kg)**
-• 1日60-90分 (朝, 夕方)
-
-  **大型犬 (25kg 以上)**
-• 1日90-120分 (活発な運動が必要)活発な運動が必要
-
-**注意事項:**
-• 暑い時間帯を避ける (アスファルトの熱傷に注意)アスファルトの熱傷に注意
-• 十分な水分補給
-• 段階的に運動量を増やす''';
-    } else if (userMessage.contains('接種') || userMessage.contains('ワクチン')) {
-      return '''💉 ペットの予防接種スケジュール:
-
-**犬の基本ワクチン:**
-• 6-8週: 1回目の総合ワクチン
-• 10-12週: 2回目の総合ワクチン + コロナ
-• 14-16週: 3回目の総合ワクチン + 狂犬病
-
-**年1回の追加接種:**
-• 総合ワクチン (年1回)
-• 狂犬病 (年1回)
-• 心臓虫 (月1回)
-
-獣医師と相談して、個別のスケジュールを立てることができます!''';
-    } else {
-      return '''ペットについての質問ですね! 🐾
-
-より正確な回答のために、より具体的な状況を教えてください:
-• ペットの種類と年齢
-• 現在の症状や状況
-• いつから問題が始まったか
-
-以下の推奨質問も参考にしてください!''';
+    try {
+      // Repository를 통해 AI 응답 받기
+      final aiResponse = await repository.sendMessage(content.trim());
+      final finalMessages = List<AiMessageEntity>.from([...state.messages, aiResponse]);
+      
+      state = state.copyWith(
+        messages: finalMessages,
+        isTyping: false,
+        error: null,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        isTyping: false,
+        error: error.toString(),
+      );
     }
   }
 
   /// 채팅 기록 초기화
-  void clearChatHistory() {
-    _messages.clear();
-    _initializeMessages();
-    _notifyMessagesChanged();
+  Future<void> clearChatHistory() async {
+    final repository = ref.read(aiRepositoryProvider);
+    
+    try {
+      await repository.clearChatHistory();
+      
+      // 초기 메시지로 리셋
+      final messages = await repository.getChatHistory();
+      state = state.copyWith(
+        messages: messages,
+        isTyping: false,
+        error: null,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        error: error.toString(),
+      );
+    }
   }
 
-  /// 메시지 추가 (외부에서 사용)
-  void addMessage(AiMessageEntity message) {
-    _messages.add(message);
+}
+
+/// AI 채팅 컨트롤러 (BaseController 패턴)
+/// 
+/// UI와 Logic을 분리하여 UI에서는 이 Controller를 통해서만 데이터에 접근합니다.
+class AiChatController extends BaseController {
+  AiChatController(super.ref);
+
+  /// 채팅 상태 스트림 제공 (UI에서 구독)
+  AiChatState get chatState => ref.read(aiChatNotifierProvider);
+
+  /// 채팅 상태 변경 감지 (UI에서 사용)
+  AiChatState watchChatState() {
+    return ref.watch(aiChatNotifierProvider);
   }
 
-  /// 메시지 목록 업데이트 알림을 위한 콜백
-  Function()? onMessagesChanged;
-
-  /// 메시지 변경 알림
-  void _notifyMessagesChanged() {
-    onMessagesChanged?.call();
+  /// 초기 데이터 로드
+  Future<void> initializeChat() async {
+    await safeExecute(
+      () async {
+        final notifier = ref.read(aiChatNotifierProvider.notifier);
+        await notifier.initializeChat();
+      },
+      errorMessage: 'チャット初期化に失敗しました',
+    );
   }
+
+  /// 메시지 전송
+  Future<void> sendMessage(String content) async {
+    if (content.trim().isEmpty) return;
+
+    await safeExecute(
+      () async {
+        final notifier = ref.read(aiChatNotifierProvider.notifier);
+        await notifier.sendMessage(content);
+      },
+      errorMessage: 'メッセージの送信に失敗しました',
+    );
+  }
+
+  /// 채팅 기록 초기화
+  Future<void> clearChatHistory() async {
+    await safeExecute(
+      () async {
+        final notifier = ref.read(aiChatNotifierProvider.notifier);
+        await notifier.clearChatHistory();
+      },
+      errorMessage: 'チャット履歴のクリアに失敗しました',
+    );
+  }
+
+  /// 현재 메시지 목록 가져오기
+  List<AiMessageEntity> get messages => chatState.messages;
+
+  /// 추천 질문 목록 가져오기  
+  List<AiSuggestedQuestionEntity> get suggestedQuestions => chatState.suggestedQuestions;
+
+  /// 타이핑 상태 확인
+  bool get isTyping => chatState.isTyping;
+
+  /// 에러 상태 확인
+  String? get error => chatState.error;
 }

--- a/lib/features/ai/presentation/controllers/ai_chat_controller.g.dart
+++ b/lib/features/ai/presentation/controllers/ai_chat_controller.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ai_chat_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$aiChatNotifierHash() => r'60b04bbb5b1cde67c0a1f527c99987286620f5a6';
+
+/// AI 채팅 상태 프로바이더
+///
+/// Copied from [AiChatNotifier].
+@ProviderFor(AiChatNotifier)
+final aiChatNotifierProvider =
+    AutoDisposeNotifierProvider<AiChatNotifier, AiChatState>.internal(
+      AiChatNotifier.new,
+      name: r'aiChatNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$aiChatNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$AiChatNotifier = AutoDisposeNotifier<AiChatState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/home/presentation/controllers/health_summary_controller.dart
+++ b/lib/features/home/presentation/controllers/health_summary_controller.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 import '../../../../app/controllers/base_controller.dart';
-import '../../../scheduling/domain/repositories/schedule_repository.dart';
-import '../../../scheduling/domain/entities/schedule_entity.dart';
 import '../../../scheduling/data/repositories/schedule_repository_impl.dart';
+import '../../../scheduling/domain/entities/schedule_entity.dart';
+import '../../../scheduling/domain/repositories/schedule_repository.dart';
 
 class HealthSummaryResult {
   final bool isSuccess;

--- a/lib/features/home/presentation/controllers/weather_controller.dart
+++ b/lib/features/home/presentation/controllers/weather_controller.dart
@@ -30,8 +30,9 @@ class WeatherController extends BaseController {
     if (weatherId == 731 || weatherId == 761) return 'dust';
     if (weatherId == 781) return 'tornado';
     if (weatherId == 800) return isDay ? 'clear-day' : 'clear-night';
-    if (weatherId == 801)
+    if (weatherId == 801) {
       return isDay ? 'partly-cloudy-day' : 'partly-cloudy-night';
+    }
     return 'wind';
   }
 

--- a/lib/features/pet_activities/domain/usecases/register_youtube_video_usecase.dart
+++ b/lib/features/pet_activities/domain/usecases/register_youtube_video_usecase.dart
@@ -1,6 +1,6 @@
+import '../../../../shared/mock_data/mock_data_service.dart';
 import '../entities/youtube_video_entity.dart';
 import '../repositories/pet_activities_repository.dart';
-import '../../../../shared/mock_data/mock_data_service.dart';
 
 /// YouTube 비디오 등록 유스케이스
 class RegisterYouTubeVideoUseCase {

--- a/lib/features/pet_feeding/presentation/screens/screens.dart
+++ b/lib/features/pet_feeding/presentation/screens/screens.dart
@@ -1,3 +1,3 @@
 export 'add_recipe_screen.dart';
-export 'recipe_screen.dart';
 export 'feeding_main_screen.dart';
+export 'recipe_screen.dart';

--- a/lib/features/pet_profile/presentation/controllers/pet_profile_controller.dart
+++ b/lib/features/pet_profile/presentation/controllers/pet_profile_controller.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../shared/shared.dart';
-
 /// 펫 프로필 컨트롤러
 class PetProfileController extends StateNotifier<PetProfileState> {
   PetProfileController() : super(const PetProfileState());

--- a/lib/features/scheduling/presentation/controllers/controllers.dart
+++ b/lib/features/scheduling/presentation/controllers/controllers.dart
@@ -1,7 +1,7 @@
 // Controllers
+export 'add_feeding_record_controller.dart';
 export 'feeding_analysis_controller.dart';
 export 'feeding_records_controller.dart';
 export 'feeding_schedule_controller.dart';
 export 'main_scheduling_controller.dart';
 export 'schedule_controller.dart';
-export 'add_feeding_record_controller.dart';

--- a/lib/shared/branding/logo_widget.dart
+++ b/lib/shared/branding/logo_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../design/color.dart';
-import '../design/radius.dart';
 
 class LogoWidget extends StatelessWidget {
   final String imagePath;
@@ -22,16 +21,12 @@ class LogoWidget extends StatelessWidget {
     return Container(
       width: width,
       height: height,
-      decoration: BoxDecoration(
-        color: backgroundColor ?? AppColors.pointCream,
-        borderRadius: BorderRadius.circular(AppRadius.medium),
-      ),
+      decoration: BoxDecoration(color: backgroundColor ?? AppColors.pointCream),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(AppRadius.medium),
         child: Image.asset(
           imagePath,
-          width: width - 16,
-          height: height - 16,
+          width: width - 8,
+          height: height - 8,
           fit: BoxFit.contain,
           errorBuilder: (context, error, stackTrace) =>
               SizedBox(width: width - 16, height: height - 16),

--- a/lib/shared/mock_data/ai_mock_data.dart
+++ b/lib/shared/mock_data/ai_mock_data.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+
+/// AI 관련 Mock 데이터 서비스
+/// 
+/// 실제 API 연계 전까지 사용하는 Mock 데이터를 중앙 관리합니다.
+/// API 연계 시점에는 이 클래스의 구현만 실제 API 호출로 변경하면 됩니다.
+class AiMockDataService {
+  /// 초기 메시지
+  static const String initialMessage = 'こんにちは！ aipetアシスタントです。 何かお手伝いできますか? 🐾';
+
+  /// 추천 질문 목록
+  static const List<Map<String, dynamic>> suggestedQuestions = [
+    {
+      'id': '1',
+      'question': 'お腹の調子が悪い',
+      'category': '食事',
+      'icon': Icons.restaurant,
+      'description': '食事量が少ない理由と解決策',
+    },
+    {
+      'id': '2',
+      'question': '散歩の時間はどれくらいかかりますか?',
+      'category': '運動',
+      'icon': Icons.directions_walk,
+      'description': '適切な運動量のガイド',
+    },
+    {
+      'id': '3',
+      'question': '予防接種のスケジュールが気になります',
+      'category': '健康',
+      'icon': Icons.medical_services,
+      'description': '予防接種の予定の案内',
+    },
+    {
+      'id': '4',
+      'question': '毛づくりのマニュアル',
+      'category': 'メンテナンス',
+      'icon': Icons.content_cut,
+      'description': '季節別毛づくりのマニュアル',
+    },
+  ];
+
+  /// AI 응답 템플릿
+  static const Map<String, String> responseTemplates = {
+    'food': '''🍽️ お腹の調子が悪い理由はたくさんあります:
+
+1. **健康上の問題**: 歯の問題, 消化器の問題
+2. **ストレス**: 環境の変化, 新しい食事
+3. **活動量不足**: 運動が不足すると食欲が落ちます
+
+**解決策:**
+• 定められた時間に定期的に食事
+• 食器を清潔に保つ
+• 十分な運動でエネルギーを消費
+• 継続的に症状があれば獣医師に相談を推奨''',
+
+    'exercise': '''🚶‍♂️ ペットの散歩ガイド:
+
+**小型犬 (5kg 未満)**
+• 1日30-60分 (2-3回に分けて)
+
+**中型犬 (5-25kg)**
+• 1日60-90分 (朝, 夕方)
+
+**大型犬 (25kg 以上)**
+• 1日90-120分 (活発な運動が必要)
+
+**注意事項:**
+• 暑い時間帯を避ける (アスファルトの熱傷に注意)
+• 十分な水分補給
+• 段階的に運動量を増やす''',
+
+    'vaccination': '''💉 ペットの予防接種スケジュール:
+
+**犬の基本ワクチン:**
+• 6-8週: 1回目の総合ワクチン
+• 10-12週: 2回目の総合ワクチン + コロナ
+• 14-16週: 3回目の総合ワクチン + 狂犬病
+
+**年1回の追加接種:**
+• 総合ワクチン (年1回)
+• 狂犬病 (年1回)
+• 心臓虫 (月1回)
+
+獣医師と相談して、個別のスケジュールを立てることができます!''',
+
+    'default': '''ペットについての質問ですね! 🐾
+
+より正確な回答のために、より具体的な状況を教えてください:
+• ペットの種類と年齢
+• 現在の症状や状況
+• いつから問題が始まったか
+
+以下の推奨質問も参考にしてください!''',
+  };
+
+  /// 키워드별 응답 매핑
+  static const Map<String, List<String>> keywordMapping = {
+    'food': ['食事', '食事量', '食事量が少ない', 'お腹'],
+    'exercise': ['散歩', '運動', '時間'],
+    'vaccination': ['接種', 'ワクチン', '予防接種'],
+  };
+
+  /// 키워드 기반 응답 생성
+  static String getResponseByKeyword(String userMessage) {
+    for (final entry in keywordMapping.entries) {
+      for (final keyword in entry.value) {
+        if (userMessage.contains(keyword)) {
+          return responseTemplates[entry.key] ?? responseTemplates['default']!;
+        }
+      }
+    }
+    return responseTemplates['default']!;
+  }
+
+  /// 채팅 히스토리 Mock 데이터 생성
+  static List<Map<String, dynamic>> getChatHistoryMockData() {
+    return [
+      {
+        'id': '1',
+        'content': initialMessage,
+        'type': 'assistant',
+        'timestamp': DateTime.now().subtract(const Duration(minutes: 5)).toIso8601String(),
+      }
+    ];
+  }
+
+  /// AI 응답 Mock 데이터 생성
+  static Map<String, dynamic> generateAiResponseMockData(String userMessage) {
+    return {
+      'id': DateTime.now().millisecondsSinceEpoch.toString(),
+      'content': getResponseByKeyword(userMessage),
+      'type': 'assistant',
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+  }
+
+  /// 채팅 세션 Mock 데이터 생성
+  static Map<String, dynamic> createChatSessionMockData(String title, {String? petId}) {
+    return {
+      'id': DateTime.now().millisecondsSinceEpoch.toString(),
+      'title': title,
+      'messages': [],
+      'createdAt': DateTime.now().toIso8601String(),
+      'updatedAt': DateTime.now().toIso8601String(),
+      'petId': petId,
+      'petName': null,
+    };
+  }
+
+  /// API 지연 시뮬레이션
+  static Future<void> simulateApiDelay({int seconds = 1}) async {
+    await Future.delayed(Duration(seconds: seconds));
+  }
+}

--- a/lib/shared/mock_data/base/mock_data_base.dart
+++ b/lib/shared/mock_data/base/mock_data_base.dart
@@ -1,0 +1,47 @@
+/// Mock Data 기본 설정 및 공통 기능
+///
+/// 모든 Mock Data 서비스의 기본이 되는 설정과 공통 기능을 제공합니다.
+abstract class MockDataBase {
+  /// Mock 데이터 사용 플래그
+  /// false로 설정하면 실제 API 호출로 전환됩니다.
+  static const bool isEnabled = true;
+
+  /// API 지연 시뮬레이션
+  static Future<void> simulateApiDelay({int milliseconds = 300}) async {
+    if (isEnabled) {
+      await Future.delayed(Duration(milliseconds: milliseconds));
+    }
+  }
+
+  /// 에러 시뮬레이션 (테스트용)
+  static Future<void> simulateError({String message = 'Mock Error'}) async {
+    if (isEnabled) {
+      await Future.delayed(const Duration(milliseconds: 100));
+      throw Exception(message);
+    }
+  }
+
+  /// 랜덤 ID 생성
+  static String generateId() {
+    return DateTime.now().millisecondsSinceEpoch.toString();
+  }
+
+  /// 랜덤 날짜 생성 (최근 N일 내)
+  static DateTime generateRandomDate({int daysAgo = 30}) {
+    final now = DateTime.now();
+    final random = DateTime.now().millisecondsSinceEpoch % daysAgo;
+    return now.subtract(Duration(days: random));
+  }
+
+  /// 랜덤 평점 생성 (1.0 ~ 5.0)
+  static double generateRandomRating() {
+    final random = DateTime.now().millisecondsSinceEpoch % 50;
+    return 1.0 + (random / 10);
+  }
+
+  /// 랜덤 리뷰 수 생성
+  static int generateRandomReviewCount() {
+    final random = DateTime.now().millisecondsSinceEpoch % 500;
+    return 10 + random;
+  }
+}

--- a/lib/shared/mock_data/base/mock_data_constants.dart
+++ b/lib/shared/mock_data/base/mock_data_constants.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+/// Mock Data 공통 상수
+///
+/// 모든 Mock Data 서비스에서 공통으로 사용되는 상수들을 정의합니다.
+class MockDataConstants {
+  // ==================== 기본 이미지 경로 ====================
+
+  /// 기본 플레이스홀더 이미지
+  static const String placeholderImage = 'assets/images/placeholder.png';
+
+  /// 기본 펫 이미지들
+  static const Map<String, String> defaultPetImages = {
+    'dog': 'assets/images/dogs/shiba.png',
+    'cat': 'assets/images/cats/cats.png',
+    'golden': 'assets/images/dogs/golden.png',
+  };
+
+  // ==================== 기본 색상 ====================
+
+  /// 기본 브랜드 색상
+  static const Color primaryColor = Color(0xFF8B5A2B);
+  static const Color secondaryColor = Color(0xFF6B4423);
+  static const Color accentColor = Color(0xFFF2A65A);
+
+  // ==================== 기본 텍스트 ====================
+
+  /// 기본 펫 이름들
+  static const List<String> defaultPetNames = ['マックス', 'ルナ', 'バディ', 'ココ', 'モモ'];
+
+  /// 기본 품종들
+  static const Map<String, List<String>> defaultBreeds = {
+    'dog': ['ゴールデンレトリバー', '柴犬', 'プードル', 'ラブラドール', 'ブルドッグ'],
+    'cat': ['ペルシャ', 'メインクーン', 'シャム', 'ラグドール', 'ブリティッシュショートヘア'],
+  };
+
+  // ==================== 기본 시간 설정 ====================
+
+  /// 기본 식사 시간들
+  static const List<String> defaultMealTimes = [
+    '08:00', // 아침
+    '12:00', // 점심
+    '18:00', // 저녁
+  ];
+
+  /// 기본 산책 시간들
+  static const List<String> defaultWalkTimes = [
+    '07:00', // 아침 산책
+    '17:00', // 저녁 산책
+  ];
+
+  // ==================== 기본 수량 설정 ====================
+
+  /// 기본 급여량 (g)
+  static const Map<String, int> defaultFeedingAmounts = {
+    'small': 80, // 소형
+    'medium': 150, // 중형
+    'large': 250, // 대형
+  };
+
+  /// 기본 산책 거리 (km)
+  static const Map<String, double> defaultWalkDistances = {
+    'small': 1.0, // 소형
+    'medium': 2.0, // 중형
+    'large': 3.0, // 대형
+  };
+
+  // ==================== 기본 상태값 ====================
+
+  /// 기본 건강 상태들
+  static const List<String> defaultHealthStatuses = [
+    '健康',
+    '疲れている',
+    '食欲不振',
+    '活発',
+  ];
+
+  /// 기본 식사 상태들
+  static const List<String> defaultFeedingStatuses = ['完食', '残食', '拒食', '食欲旺盛'];
+
+  // ==================== 기본 메시지 ====================
+
+  /// 기본 성공 메시지
+  static const String defaultSuccessMessage = '正常に処理されました';
+
+  /// 기본 에러 메시지
+  static const String defaultErrorMessage = 'エラーが発生しました';
+
+  /// 기본 로딩 메시지
+  static const String defaultLoadingMessage = '読み込み中...';
+
+  // ==================== 기본 설정값 ====================
+
+  /// 기본 페이지 크기
+  static const int defaultPageSize = 20;
+
+  /// 기본 새로고침 간격 (초)
+  static const int defaultRefreshInterval = 30;
+
+  /// 기본 캐시 유효 시간 (분)
+  static const int defaultCacheExpiration = 60;
+}

--- a/lib/shared/mock_data/features/pet/pet_mock_data.dart
+++ b/lib/shared/mock_data/features/pet/pet_mock_data.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+
+import '../../../features/pet_registor/domain/entities/pet_profile_entity.dart';
+import '../../base/mock_data_base.dart';
+import '../../base/mock_data_constants.dart';
+
+/// 펫 관련 Mock 데이터 서비스
+///
+/// 펫 프로필, 등록, 기본 정보와 관련된 Mock 데이터를 제공합니다.
+class PetMockData {
+  /// 펫 목록 Mock 데이터
+  static List<PetProfileEntity> getMockPets() {
+    return [
+      PetProfileEntity(
+        id: '1',
+        name: 'マックス',
+        type: 'dog',
+        breed: 'ゴールデンレトリバー',
+        birthDate: DateTime(2020, 3, 15),
+        imagePath: MockDataConstants.defaultPetImages['dog']!,
+        ownerId: 'user1',
+        createdAt: DateTime.now().subtract(const Duration(days: 30)),
+        updatedAt: DateTime.now(),
+      ),
+      PetProfileEntity(
+        id: '2',
+        name: 'ルナ',
+        type: 'cat',
+        breed: 'ペルシャ',
+        birthDate: DateTime(2021, 7, 22),
+        imagePath: MockDataConstants.defaultPetImages['cat']!,
+        ownerId: 'user1',
+        createdAt: DateTime.now().subtract(const Duration(days: 15)),
+        updatedAt: DateTime.now(),
+      ),
+    ];
+  }
+
+  /// 특정 펫 Mock 데이터
+  static PetProfileEntity? getMockPetById(String id) {
+    final pets = getMockPets();
+    try {
+      return pets.firstWhere((pet) => pet.id == id);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// 강아지 품종 Mock 데이터
+  static List<Map<String, dynamic>> getMockDogBreeds() {
+    return [
+      {
+        'breed': 'poodle',
+        'name': 'プードル',
+        'image': 'assets/images/breeds/poodle.png',
+      },
+      {
+        'breed': 'golden_retriever',
+        'name': 'ゴールデンレトリーバー',
+        'image': 'assets/images/breeds/golden_retriever.png',
+      },
+      {
+        'breed': 'labrador',
+        'name': 'ラブラドール',
+        'image': 'assets/images/breeds/labrador.png',
+      },
+      {
+        'breed': 'shiba_inu',
+        'name': '柴犬',
+        'image': 'assets/images/breeds/shiba_inu.png',
+      },
+      {
+        'breed': 'bulldog',
+        'name': 'ブルドッグ',
+        'image': 'assets/images/breeds/bulldog.png',
+      },
+      {
+        'breed': 'chihuahua',
+        'name': 'チワワ',
+        'image': 'assets/images/breeds/chihuahua.png',
+      },
+      {
+        'breed': 'beagle',
+        'name': 'ビーグル',
+        'image': 'assets/images/breeds/beagle.png',
+      },
+      {
+        'breed': 'german_shepherd',
+        'name': 'ジャーマンシェパード',
+        'image': 'assets/images/breeds/german_shepherd.png',
+      },
+      {
+        'breed': 'yorkshire_terrier',
+        'name': 'ヨークシャーテリア',
+        'image': 'assets/images/breeds/yorkshire_terrier.png',
+      },
+      {
+        'breed': 'dachshund',
+        'name': 'ダックスフンド',
+        'image': 'assets/images/breeds/dachshund.png',
+      },
+    ];
+  }
+
+  /// 고양이 품종 Mock 데이터
+  static List<Map<String, dynamic>> getMockCatBreeds() {
+    return [
+      {
+        'breed': 'persian',
+        'name': 'ペルシャ',
+        'image': 'assets/images/breeds/persian.png',
+      },
+      {
+        'breed': 'maine_coon',
+        'name': 'メインクーン',
+        'image': 'assets/images/breeds/maine_coon.png',
+      },
+      {
+        'breed': 'siamese',
+        'name': 'シャム',
+        'image': 'assets/images/breeds/siamese.png',
+      },
+      {
+        'breed': 'ragdoll',
+        'name': 'ラグドール',
+        'image': 'assets/images/breeds/ragdoll.png',
+      },
+      {
+        'breed': 'british_shorthair',
+        'name': 'ブリティッシュショートヘア',
+        'image': 'assets/images/breeds/british_shorthair.png',
+      },
+      {
+        'breed': 'scottish_fold',
+        'name': 'スコティッシュフォールド',
+        'image': 'assets/images/breeds/scottish_fold.png',
+      },
+    ];
+  }
+
+  /// 펫 타입 선택 Mock 데이터
+  static List<Map<String, dynamic>> getMockPetTypes() {
+    return [
+      {
+        'type': 'dog',
+        'name': 'いぬ',
+        'icon': 'pets',
+        'description': '充実스럽고 활발한 반려견',
+        'color': MockDataConstants.primaryColor,
+        'image': 'assets/images/pets/dog.png',
+      },
+      {
+        'type': 'cat',
+        'name': 'ねこ',
+        'icon': 'pets',
+        'description': '우아하고 독립적인 반려묘',
+        'color': MockDataConstants.secondaryColor,
+        'image': 'assets/images/pets/cat.png',
+      },
+      {
+        'type': 'rabbit',
+        'name': 'うさぎ',
+        'icon': 'cruelty_free',
+        'description': '귀엽고 온순한 반려토끼',
+        'color': MockDataConstants.accentColor,
+        'image': 'assets/images/pets/rabbit.png',
+      },
+      {
+        'type': 'hamster',
+        'name': 'ハムスター',
+        'icon': 'circle',
+        'description': '작고 사랑스러운 반려햄스터',
+        'color': const Color(0xFFD4A574),
+        'image': 'assets/images/pets/hamster.png',
+      },
+    ];
+  }
+
+  /// 펫 성별 판단 (이름 기반)
+  static String getPetGenderByName(String petName) {
+    final maleNames = [
+      'max',
+      'buddy',
+      'charlie',
+      'rocky',
+      'jack',
+      'oscar',
+      'leo',
+      'milo',
+    ];
+    final femaleNames = [
+      'luna',
+      'bella',
+      'molly',
+      'lucy',
+      'sophie',
+      'chloe',
+      'zoe',
+      'ruby',
+    ];
+
+    final lowerName = petName.toLowerCase();
+
+    if (maleNames.any((name) => lowerName.contains(name))) {
+      return 'male';
+    } else if (femaleNames.any((name) => lowerName.contains(name))) {
+      return 'female';
+    }
+
+    return 'unknown';
+  }
+
+  /// 펫 사이즈별 적정 급여량 Mock 데이터
+  static Map<String, Map<String, dynamic>> getMockPetSizesAndFeedingAmounts() {
+    return {
+      '1': {
+        'name': 'マックス',
+        'size': '中型',
+        'recommendedAmount': 150,
+        'imagePath': MockDataConstants.defaultPetImages['dog']!,
+      },
+      '2': {
+        'name': 'ルナ',
+        'size': '小型',
+        'recommendedAmount': 80,
+        'imagePath': MockDataConstants.defaultPetImages['cat']!,
+      },
+      '3': {
+        'name': 'バディ',
+        'size': '大型',
+        'recommendedAmount': 250,
+        'imagePath': MockDataConstants.defaultPetImages['golden']!,
+      },
+    };
+  }
+
+  /// 펫 사이즈별 급여 가이드 Mock 데이터
+  static Map<String, Map<String, dynamic>> getPetSizeFeedingGuide() {
+    return {
+      '小型': {
+        'description': '小型犬・猫 (体重5kg以下)',
+        'recommendedRange': '60-100g',
+        'tips': '소량으로 나누어 주는 것이 좋습니다',
+      },
+      '中型': {
+        'description': '中型犬・猫 (体重5-20kg)',
+        'recommendedRange': '100-200g',
+        'tips': '하루 2-3회로 나누어 주세요',
+      },
+      '大型': {
+        'description': '大型犬 (体重20kg以上)',
+        'recommendedRange': '200-400g',
+        'tips': '운동량에 따라 조절이 필요합니다',
+      },
+    };
+  }
+}

--- a/lib/shared/mock_data/mock_data.dart
+++ b/lib/shared/mock_data/mock_data.dart
@@ -1,1 +1,2 @@
+export 'ai_mock_data.dart';
 export 'mock_data_service.dart';

--- a/lib/shared/shared.dart
+++ b/lib/shared/shared.dart
@@ -23,8 +23,8 @@ export 'utils/validation_utils.dart';
 export 'widgets/accessibility/accessibility_widgets.dart';
 // Animation widgets
 export 'widgets/animation/animation_widgets.dart';
+// Pet management widgets
+export 'widgets/pet_status_selection_dialog.dart';
 // Responsive widgets
 export 'widgets/responsive/responsive_widgets.dart';
 export 'widgets/widgets.dart';
-// Pet management widgets
-export 'widgets/pet_status_selection_dialog.dart';


### PR DESCRIPTION
# 📝 PR 説明

### 🔄 / 変更理由

- ai featureコード内部でハードコードされていた　モックデータをmock_dataに分離
- uiとlogicコード分離を適応し、DRY原則に対応

---

### ✨ 主な変更点

1. コードフォルダーの分離対応
2. feature内部のdata/domain/presentationに分離確定
3. dataは直接触らず、controller + proivderを使用し、直接接続禁止


---

### ⚙️ 技術的詳細

- 分離原則、DRY適応

---

### 🚀 改善効果

- フォルダーとファイル分離の原則を確定し、Clean Architecture 適応

---

### 🔗 関連イシュー

- 特になし

---

### 🏷️ ラベル

`refactor`